### PR TITLE
Add '.' button in keyboard toolbar for IP Address

### DIFF
--- a/PrusaLink/SettingsView/SettingsView.swift
+++ b/PrusaLink/SettingsView/SettingsView.swift
@@ -40,10 +40,11 @@ struct SettingsView: View {
                                 printer.ipAddress = (printer.ipAddress ?? "") + "."
                             } label: {
                                 Text(".")
-                                    .padding(.horizontal, 8)
+                                    .padding(.horizontal, 15)
                             }
                             .buttonStyle(.borderedProminent)
                             .tint(.init(uiColor: .systemGray2))
+
                             
                             Spacer()
                             

--- a/PrusaLink/SettingsView/SettingsView.swift
+++ b/PrusaLink/SettingsView/SettingsView.swift
@@ -32,11 +32,21 @@ struct SettingsView: View {
             Section("IP Address") {
                 SettingsTextField("IP Address", text: Binding($printer.ipAddress, replacingNilWith: ""))
                 .focused($ipAddressIsFocused)
-                .keyboardType(.decimalPad)
+                .keyboardType(.numberPad)
                 .toolbar {
                     if ipAddressIsFocused {
                         ToolbarItemGroup(placement: .keyboard) {
+                            Button {
+                                printer.ipAddress = (printer.ipAddress ?? "") + "."
+                            } label: {
+                                Text(".")
+                                    .padding(.horizontal, 8)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.init(uiColor: .systemGray2))
+                            
                             Spacer()
+                            
                             Button("done") {
                                 ipAddressIsFocused = false
                             }


### PR DESCRIPTION
Adds a decimal point button in the keyboard toolbar for the IP Address text field in the printer settings view. This is needed because in some locales the decimal separator is a comma, not a period. So the decimal keyboard wasn't allowing some users to enter a period.

Fixes #2 